### PR TITLE
Slipeable drawer was changed for a normal drawer

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -57,7 +57,7 @@ const theme = createMuiTheme({
       paperAnchorTop: {
         top: "70px",
         [breakpoints.down("xs")]: {
-          height: "50rem"
+          height: "40rem"
         }
       }
     }
@@ -65,7 +65,6 @@ const theme = createMuiTheme({
 });
 
 function App({ fetchImages, fetchCollections, setUrlPathName, width }) {
-  console.log(width);
   useEffect(() => {
     fetchImages();
     fetchCollections();

--- a/src/components/slide-down-menu/slide-down-menu.component.jsx
+++ b/src/components/slide-down-menu/slide-down-menu.component.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { SwipeableDrawer } from "@material-ui/core";
+import { Drawer } from "@material-ui/core";
 import CategoryShowcase from "../category-showcase/category-showcase.component";
 import { useStyles } from "./slide-down-menu.styles";
 
@@ -7,11 +7,11 @@ const SlideDownMenu = ({ open, handleSlideMenuClose }) => {
   const classes = useStyles();
 
   return (
-    <SwipeableDrawer anchor={"top"} open={open} onClose={handleSlideMenuClose}>
+    <Drawer anchor={"top"} open={open} onClose={handleSlideMenuClose}>
       <div className={classes.categoryShowcasePosition}>
         <CategoryShowcase />
       </div>
-    </SwipeableDrawer>
+    </Drawer>
   );
 };
 


### PR DESCRIPTION
Slipeable drawer was changed for a normal drawer since the slipeable one was generating a `touchstart` event that was not letting to scroll the cart modal properly on mobile devices.